### PR TITLE
Use "localhost" as the http listener listens on that address.

### DIFF
--- a/lib/liquid-proxy.rb
+++ b/lib/liquid-proxy.rb
@@ -23,7 +23,7 @@ class LiquidProxy
     private
 
       def http
-        @http ||= Net::HTTP.new('127.0.0.1', LiquidProxy.port)
+        @http ||= Net::HTTP.new('localhost', LiquidProxy.port)
       end
   end
 

--- a/lib/utils/port_explorer.rb
+++ b/lib/utils/port_explorer.rb
@@ -3,7 +3,7 @@ require 'socket'
 module Utils
   class PortExplorer
     def self.port_occupied?(port)
-      !!Net::HTTP.get('127.0.0.1', '/', port)
+      !!Net::HTTP.get('localhost', '/', port)
     rescue => e
       !e.is_a?(Errno::ECONNREFUSED)
     else


### PR DESCRIPTION
More modern versions of Ruby on have different binding rules; and bind to ::1 if possible and not 127.0.0.1; both can be detected if we use the alias 'localhost'.
